### PR TITLE
Generate insights with only present values - not present are filtered out

### DIFF
--- a/examples/contao/analyse.sh
+++ b/examples/contao/analyse.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php bin/git-dev-insights --config projects/contao/config.yaml --weeks 150
+php bin/git-dev-insights --config examples/contao/config.yaml --weeks 150

--- a/examples/contao/config.yaml
+++ b/examples/contao/config.yaml
@@ -1,7 +1,8 @@
 # Example config to show how the tool works
 # We will inspect the contao repository here
 
-project_name: Contao
-repository_url: https://github.com/contao/contao.git
-checkout_path: insights/checkout/contao
-analyse_result_path: insights/generated/contao
+project:
+  project_name: Contao
+  repository_url: https://github.com/contao/contao.git
+  checkout_path: insights/checkout/contao
+  analyse_result_path: insights/generated/contao

--- a/examples/git-dev-insights/config.yaml
+++ b/examples/git-dev-insights/config.yaml
@@ -1,7 +1,6 @@
 # Example config to show how the tool works
 # We will inspect the git dev insights repository here
 
-
 project:
   project_name: git dev insights
   repository_url: https://github.com/standan-hulk/git-dev-insights.git

--- a/examples/redaxo/analyse.sh
+++ b/examples/redaxo/analyse.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php analyse.php --config examples/redaxo/config.yaml --weeks 150
+php bin/git-dev-insights --config examples/redaxo/config.yaml --weeks 150

--- a/examples/redaxo/config.yaml
+++ b/examples/redaxo/config.yaml
@@ -4,5 +4,5 @@
 project:
   project_name: Redaxo
   repository_url: https://github.com/redaxo/redaxo.git
-  checkout_path: source-repo/data/redaxo
-  analyse_result_path: source-repo/generated-generated/redaxo
+  checkout_path: insights/checkout/redaxo
+  analyse_result_path: insights/generated/redaxo

--- a/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
@@ -65,7 +65,11 @@ class FileExtensionChartHTMLFileGenerator
         foreach ($labels as $label) {
             $data = [];
             foreach ($dates as $date) {
-                $data[] = $this->jsonData['language-fileext-data'][$date][$label];
+                if(isset($this->jsonData['language-fileext-data'][$date][$label])) {
+                    $data[] = $this->jsonData['language-fileext-data'][$date][$label];
+                } else {
+                    $data[] = 0;
+                }
             }
 
             $datasets[] = [

--- a/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
@@ -12,6 +12,46 @@ class FileExtensionChartHTMLFileGenerator
     {
         $this->jsonData = $jsonData;
         $this->chartTitle = $chartTitle;
+        $this->jsonData['language-fileext-data'] = $this->filterDataByValuesSet();
+    }
+
+    private function getValuesSetForOutput(): array {
+        $dates = $this->jsonData['language-fileext-data'];
+
+        $valuesSet = [];
+
+        if ($dates !== []) {
+            foreach ($dates as $values) {
+                foreach ($values as $key => $value) {
+                    if ((int)$value > 0) {
+                        $valuesSet[$key] = 1;
+                    }
+                }
+            }
+        }
+        return $valuesSet;
+    }
+
+    private function filterDataByValuesSet(): array {
+        $filteredData = [];
+
+        $valuesSet = $this->getValuesSetForOutput();
+
+        foreach ($this->jsonData['language-fileext-data'] as $date => $values) {
+            $filteredValues = [];
+
+            foreach ($values as $key => $value) {
+                if (isset($valuesSet[$key]) && (int)$value > 0) {
+                    $filteredValues[$key] = $value;
+                }
+            }
+
+            if (!empty($filteredValues)) {
+                $filteredData[$date] = $filteredValues;
+            }
+        }
+
+        return $filteredData;
     }
 
     public function renderChartOutput(): string

--- a/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FileExtensionChartHTMLFileGenerator.php
@@ -34,11 +34,12 @@ class FileExtensionChartHTMLFileGenerator
 
     private function filterDataByValuesSet(): array {
         $filteredData = [];
-
         $valuesSet = $this->getValuesSetForOutput();
 
+        $keyTemplate = array_combine(array_keys($valuesSet), array_fill(0, count($valuesSet), 0));
+
         foreach ($this->jsonData['language-fileext-data'] as $date => $values) {
-            $filteredValues = [];
+            $filteredValues = $keyTemplate;
 
             foreach ($values as $key => $value) {
                 if (isset($valuesSet[$key]) && (int)$value > 0) {
@@ -46,9 +47,7 @@ class FileExtensionChartHTMLFileGenerator
                 }
             }
 
-            if (!empty($filteredValues)) {
-                $filteredData[$date] = $filteredValues;
-            }
+            $filteredData[$date] = $filteredValues;
         }
 
         return $filteredData;
@@ -65,11 +64,7 @@ class FileExtensionChartHTMLFileGenerator
         foreach ($labels as $label) {
             $data = [];
             foreach ($dates as $date) {
-                if(isset($this->jsonData['language-fileext-data'][$date][$label])) {
-                    $data[] = $this->jsonData['language-fileext-data'][$date][$label];
-                } else {
-                    $data[] = 0;
-                }
+                $data[] = $this->jsonData['language-fileext-data'][$date][$label];
             }
 
             $datasets[] = [

--- a/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
@@ -107,7 +107,7 @@ class FocusChartHTMLFileGenerator
 </head>
 <body>
 <h1>'.$this->chartTitle.' - Programming Language Trend Analysis</h1>
-<h2>Backend / Frontend usage bye programming languagees (Lines of Code)</h2>
+<h2>Backend / Frontend usage bye programming languages (Lines of Code)</h2>
 <div style="width: 80vw; height: 90vh; margin: 0 auto;">
     <canvas id="trend_chart" width="" height=""></canvas>
 </div>

--- a/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
@@ -12,11 +12,50 @@ class FocusChartHTMLFileGenerator
     {
         $this->jsonData = $jsonData;
         $this->chartTitle = $chartTitle;
+        $this->jsonData['language-focus-data'] = $this->filterDataByValuesSet();
+    }
+
+    private function getValuesSetForOutput(): array {
+        $dates = $this->jsonData['language-focus-data'];
+
+        $valuesSet = [];
+
+        if ($dates !== []) {
+            foreach ($dates as $values) {
+                foreach ($values as $key => $value) {
+                    if ((int)$value > 0) {
+                        $valuesSet[$key] = 1;
+                    }
+                }
+            }
+        }
+        return $valuesSet;
+    }
+
+    private function filterDataByValuesSet(): array {
+        $filteredData = [];
+
+        $valuesSet = $this->getValuesSetForOutput();
+
+        foreach ($this->jsonData['language-focus-data'] as $date => $values) {
+            $filteredValues = [];
+
+            foreach ($values as $key => $value) {
+                if (isset($valuesSet[$key]) && (int)$value > 0) {
+                    $filteredValues[$key] = $value;
+                }
+            }
+
+            if (!empty($filteredValues)) {
+                $filteredData[$date] = $filteredValues;
+            }
+        }
+
+        return $filteredData;
     }
 
     public function renderChartOutput(): string
     {
-        // Extract dates and labels
         $dates = array_keys(array_reverse($this->jsonData['language-focus-data']));
         $labels = array_keys($this->jsonData['language-focus-data'][$dates[0]]);
 
@@ -24,6 +63,7 @@ class FocusChartHTMLFileGenerator
         $datasets = [];
         foreach ($labels as $label) {
             $data = [];
+
             foreach ($dates as $date) {
                 $data[] = $this->jsonData['language-focus-data'][$date][$label];
             }

--- a/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
@@ -34,11 +34,12 @@ class FocusChartHTMLFileGenerator
 
     private function filterDataByValuesSet(): array {
         $filteredData = [];
-
         $valuesSet = $this->getValuesSetForOutput();
 
+        $keyTemplate = array_combine(array_keys($valuesSet), array_fill(0, count($valuesSet), 0));
+
         foreach ($this->jsonData['language-focus-data'] as $date => $values) {
-            $filteredValues = [];
+            $filteredValues = $keyTemplate;
 
             foreach ($values as $key => $value) {
                 if (isset($valuesSet[$key]) && (int)$value > 0) {
@@ -46,9 +47,7 @@ class FocusChartHTMLFileGenerator
                 }
             }
 
-            if (!empty($filteredValues)) {
-                $filteredData[$date] = $filteredValues;
-            }
+            $filteredData[$date] = $filteredValues;
         }
 
         return $filteredData;
@@ -66,11 +65,7 @@ class FocusChartHTMLFileGenerator
             $data = [];
 
             foreach ($dates as $date) {
-                if(isset($this->jsonData['language-focus-data'][$date][$label])) {
-                    $data[] = $this->jsonData['language-focus-data'][$date][$label];
-                } else {
-                    $data[] = 0;
-                }
+                $data[] = $this->jsonData['language-focus-data'][$date][$label];
             }
 
             $datasets[] = [

--- a/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/FocusChartHTMLFileGenerator.php
@@ -62,10 +62,15 @@ class FocusChartHTMLFileGenerator
         // Generate datasets for each label
         $datasets = [];
         foreach ($labels as $label) {
+
             $data = [];
 
             foreach ($dates as $date) {
-                $data[] = $this->jsonData['language-focus-data'][$date][$label];
+                if(isset($this->jsonData['language-focus-data'][$date][$label])) {
+                    $data[] = $this->jsonData['language-focus-data'][$date][$label];
+                } else {
+                    $data[] = 0;
+                }
             }
 
             $datasets[] = [

--- a/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
@@ -12,7 +12,48 @@ class LanguageChartHTMLFileGenerator
     {
         $this->jsonData = $jsonData;
         $this->chartTitle = $chartTitle;
+        $this->jsonData['language-global-data'] = $this->filterDataByValuesSet();
     }
+
+    private function getValuesSetForOutput(): array {
+        $dates = $this->jsonData['language-global-data'];
+
+        $valuesSet = [];
+
+        if ($dates !== []) {
+            foreach ($dates as $values) {
+                foreach ($values as $key => $value) {
+                    if ((int)$value > 0) {
+                        $valuesSet[$key] = 1;
+                    }
+                }
+            }
+        }
+        return $valuesSet;
+    }
+
+    private function filterDataByValuesSet(): array {
+        $filteredData = [];
+
+        $valuesSet = $this->getValuesSetForOutput();
+
+        foreach ($this->jsonData['language-global-data'] as $date => $values) {
+            $filteredValues = [];
+
+            foreach ($values as $key => $value) {
+                if (isset($valuesSet[$key]) && (int)$value > 0) {
+                    $filteredValues[$key] = $value;
+                }
+            }
+
+            if (!empty($filteredValues)) {
+                $filteredData[$date] = $filteredValues;
+            }
+        }
+
+        return $filteredData;
+    }
+
 
     public function renderChartOutput(): string
     {

--- a/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
@@ -34,11 +34,12 @@ class LanguageChartHTMLFileGenerator
 
     private function filterDataByValuesSet(): array {
         $filteredData = [];
-
         $valuesSet = $this->getValuesSetForOutput();
 
+        $keyTemplate = array_combine(array_keys($valuesSet), array_fill(0, count($valuesSet), 0));
+
         foreach ($this->jsonData['language-global-data'] as $date => $values) {
-            $filteredValues = [];
+            $filteredValues = $keyTemplate;
 
             foreach ($values as $key => $value) {
                 if (isset($valuesSet[$key]) && (int)$value > 0) {
@@ -46,14 +47,11 @@ class LanguageChartHTMLFileGenerator
                 }
             }
 
-            if (!empty($filteredValues)) {
-                $filteredData[$date] = $filteredValues;
-            }
+            $filteredData[$date] = $filteredValues;
         }
 
         return $filteredData;
     }
-
 
     public function renderChartOutput(): string
     {
@@ -66,11 +64,7 @@ class LanguageChartHTMLFileGenerator
         foreach ($labels as $label) {
             $data = [];
             foreach ($dates as $date) {
-                if(isset($this->jsonData['language-global-data'][$date][$label])) {
-                    $data[] = $this->jsonData['language-global-data'][$date][$label];
-                } else {
-                    $data[] = 0;
-                }
+                $data[] = $this->jsonData['language-global-data'][$date][$label];
             }
 
             $datasets[] = [

--- a/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
+++ b/src/GitDevInsights/CodeInsights/Output/LanguageChartHTMLFileGenerator.php
@@ -66,7 +66,11 @@ class LanguageChartHTMLFileGenerator
         foreach ($labels as $label) {
             $data = [];
             foreach ($dates as $date) {
-                $data[] = $this->jsonData['language-global-data'][$date][$label];
+                if(isset($this->jsonData['language-global-data'][$date][$label])) {
+                    $data[] = $this->jsonData['language-global-data'][$date][$label];
+                } else {
+                    $data[] = 0;
+                }
             }
 
             $datasets[] = [


### PR DESCRIPTION
if a file extension or programming language is not present, wie don't have to include it in the output chart

closes https://github.com/standan-hulk/git-dev-insights/issues/41